### PR TITLE
Cancel refactor

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -178,6 +178,26 @@
     Fliplet.Studio.emit('reload-page-preview');
   });
 
+  Fliplet.Widget.onCancelRequest(function() {
+    console.log(menusPromises)
+    if (menusPromises) {
+      for (var key in menusPromises) {
+        // skip loop if the property is from prototype
+        if (!menusPromises.hasOwnProperty(key)) continue;
+
+        var obj = menusPromises[key];
+        for (var prop in obj) {
+          // skip loop if the property is from prototype
+          if(!obj.hasOwnProperty(prop)) continue;
+
+          obj[prop].forwardCancelRequest()
+        }
+      }
+    }
+    if (!currentProvider) return;
+    currentProvider.forwardCancelRequest()
+  });
+
   function fetchCustomMenus() {
     return Fliplet.API.request({
       url: [

--- a/js/interface.js
+++ b/js/interface.js
@@ -179,7 +179,6 @@
   });
 
   Fliplet.Widget.onCancelRequest(function() {
-    console.log(menusPromises)
     if (menusPromises) {
       for (var key in menusPromises) {
         // skip loop if the property is from prototype
@@ -190,12 +189,12 @@
           // skip loop if the property is from prototype
           if(!obj.hasOwnProperty(prop)) continue;
 
-          obj[prop].forwardCancelRequest()
+          obj[prop].forwardCancelRequest();
         }
       }
     }
-    if (!currentProvider) return;
-    currentProvider.forwardCancelRequest()
+    if (!currentProvider) { return; }
+    currentProvider.forwardCancelRequest();
   });
 
   function fetchCustomMenus() {


### PR DESCRIPTION
Using the new `.onCancelRequest()` and `.forwardCancelRequest()`

*Note:* the `for` loop is because each menu item creates a link provider.