### PR TITLE
Ensures the user sees "Custom menu" as the name of a custom menu

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -47,6 +47,9 @@
 
       $("#panel-holder").show();
       dataSources.forEach(function(dataSource) {
+        if (dataSource.name !== 'Custom menu') {
+          dataSource.name = 'Custom menu';
+        }
         addMenu(dataSource);
       });
 


### PR DESCRIPTION
This will only update the name in the frontend, it won't save the new name, since we are going to change it via DB, that way I don't have to refactor more code.

Ref: https://github.com/Fliplet/fliplet-studio/issues/3195