### PR TITLE
Do not duplicate users menu items on saving

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -467,10 +467,12 @@
       var isMenuItemExists = menuDataEntries.some(function(entry) {
         return entry.entryId === menuItem.id;
       });
+      var menuItemOrder = sortedIds.indexOf(menuItem.id.toString());
 
-      if (!isMenuItemExists) {
+      // if menuItemOreder === 1 it means that no such DOM elem and we shouldn't add it
+      if (!isMenuItemExists && menuItemOrder !== -1) {
         // Update link order in case it was chaged by the user
-        menuItem.data.order = sortedIds.indexOf(menuItem.id.toString());
+        menuItem.data.order = menuItemOrder;
 
         // Update link label in case it was changed by the user
         menuItem.data.linkLabel = $('[data-id="' + menuItem.id + '"]').find('.link-label').val();


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6113#issuecomment-603215247

## Description
Do not duplicate users menu items on saving

## Screenshots/screencasts
https://share.getcloudapp.com/z8uXoABX

## Backward compatibility

This change is fully backward compatible.