### PR TITLE
Confirmation message is displayed when saving menu

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -308,6 +308,8 @@
   }
 
   function saveManager() {
+    showSuccessMessage();
+
     if (!currentDataSource) {
       topMenu.id = $appMenu.val();
       return Fliplet.App.Settings.set({
@@ -352,8 +354,6 @@
     menusPromises[currentDataSource.id].forEach(function(linkActionProvider) {
       linkActionProvider.forwardSaveRequest();
     });
-
-    showSuccessMessage();
   }
 
   function showSuccessMessage() {


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6362

## Description
The issue occured because when saving menu as "Hide menu" or "All screens" saveManager function returned at line 315 and did not reach showSuccessMessage() function.

## Screenshots/screencasts
![menu-manager](https://user-images.githubusercontent.com/52824207/81468619-5bb1ae00-91e9-11ea-9f7b-5c42f968d52b.gif)

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko