### PR TITLE
[Fix] Change save button label back to `Save` after file picker in link provider is closed

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -492,8 +492,15 @@
       data: row.data.action,
       // Events fired from the provider
       onEvent: function(event, data) {
-        if (event === 'interface-validate') {
-          Fliplet.Widget.toggleSaveButton(data.isValid === true);
+        switch (event) {
+          case 'inteface-validate':
+            Fliplet.Widget.toggleSaveButton(!!data.isValid);
+            break;
+          case 'file-picker-closed':
+            Fliplet.Widget.setSaveButtonLabel('Save');
+            break;
+          default:
+            break;
         }
       },
       closeOnSave: false


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5564

## Description
Change save button label back to `Save` after file picker in link provider is closed

## Screenshots/screencasts
https://share.getcloudapp.com/WnuG8pRE

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
This fix will work only after merging this [PR](https://github.com/Fliplet/fliplet-widget-link/pull/51)