### PR TITLE
[Fix] Disable the save button when no icon is selected

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -269,8 +269,15 @@
       data: row.data,
       // Events fired from the provider
       onEvent: function(event, data) {
-        if (event === 'interface-validate') {
-          Fliplet.Widget.toggleSaveButton(data.isValid === true);
+        switch (event) {
+          case 'interface-validate':
+            Fliplet.Widget.toggleSaveButton(data.isValid === true);
+            break;
+          case 'icon-clicked':
+            Fliplet.Widget.toggleSaveButton(data.isSelected);
+            break;
+          default:
+            break;
         }
       }
     });


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5651

## Description
Disable the save button when no icon is selected

## Screenshots/screencasts
https://share.getcloudapp.com/P8uErz9r

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko