### PR TITLE
[Fix] Progressively render custom menu items when relevant

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -16,16 +16,20 @@
         <div class="menu-styles-wrapper">
           <div class="instance-loading">
             <div class="spinner-holder animated">
-              <div class="spinner-overlay">Loading...</div>
+              <div class="spinner-overlay"></div>
               <p>Loading...</p>
             </div>
           </div>
           <div class="custom-menus clearfix"></div>
         </div>
       </div>
-      <div role="tabpanel" class="tab-pane" id="menu-manager">      
+      <div role="tabpanel" class="tab-pane" id="menu-manager">
+        <div class="spinner-holder animated" id="menu-manager-loading">
+          <div class="spinner-overlay"></div>
+          <p>Loading...</p>
+        </div>
 
-        <div class="" id="panel-holder" style="display: none">
+        <div id="panel-holder" style="display: none">
           <form class="form-horizontal">
 
             <div class="form-group">
@@ -39,7 +43,6 @@
                     <option value="pages" selected>All screens</option>
                   </select>
                   <span class="icon fa fa-chevron-down"></span>
-                  <span class="select-value-proxy">All screens</span>
                 </label>
               </div>
             </div>
@@ -47,6 +50,10 @@
           </form>
           <div id="menu-links" style="display: none">
             <div class="panel-group ui-sortable" id="accordion">
+              <div class="spinner-holder animated" id="menu-loading" style="display: none">
+                <div class="spinner-overlay"></div>
+                <p>Loading...</p>
+              </div>
               <!-- LINKS -->
             </div>
 

--- a/interface.html
+++ b/interface.html
@@ -75,7 +75,7 @@
 </template>
 
 <template id="template-menu">
-  <div class="menu" id="menu-\{{id}}" style="display: none"></div>
+  <div class="menu" id="menu-\{{id}}"></div>
 </template>
 
 <script id="template-menuWidget" type="text/template">

--- a/js/interface.js
+++ b/js/interface.js
@@ -141,8 +141,6 @@
       }
 
       getMenu.then(function () {
-        // Show only the selected one
-        $('#menu-' + menuId).show();
         $('#add-link').show();
 
         return Fliplet.DataSources.connect(menuId)


### PR DESCRIPTION
Ref. https://github.com/Fliplet/fliplet-studio/issues/6606

- List of custom menus is not loaded until user switches to the **Menu links** tab
- List of menu items in each custom menu is not loaded until user selects the custom menu
- If user switches away from the custom menu, menu items in the old custom menu are removed from the page DOM to clear memory and any related network requests
- Adds more loading spinner states