### PR TITLE
[Fix] Showing correct control labels for users in every situation.

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -46,7 +46,7 @@
         Fliplet.Widget.setCancelButtonLabel('Cancel');
         break;
       case 'settings':
-        Fliplet.Widget.setSaveButtonLabel('Save&Close');
+        Fliplet.Widget.setSaveButtonLabel('Save & Close');
         Fliplet.Widget.setCancelButtonLabel('Cancel');
         break;
       default:


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6403
https://github.com/Fliplet/fliplet-studio/issues/6612

## Description
Showing correct control labels for users in every situation.

## Screenshots/screencasts
https://share.getcloudapp.com/6qu22yYO

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko

## Notes
In order to be aware of when we press the cancel button in file picker called from the link provider, we are using this `checkIfFilePickerClosing` function.