### PR TITLE
OD-425 [Fix] Prevent menu items duplication on save after changing selected custom menu

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -184,6 +184,7 @@
           return;
         }
 
+        currentMenuItems = [];
         getMenu = addMenu(dataSource);
       }
 


### PR DESCRIPTION
@sofiiakvasnevska
## Issue
OD-425 https://weboo.atlassian.net/browse/OD-425
## Description
Prevents menu items duplication on save after changing selected custom menu.
## Screenshots/screencasts
https://monosnap.com/file/OPne9KkZNAtJSuC5m8zYM4hzCOaZZz
## Backward compatibility
This change is fully backward compatible.
## Reviewers 
@upplabs-alex-levchenko @AndrRyaz @YaroslavOvdii