### PR TITLE
PS-1810: Fix menu items duplication in mergeMenuEntries (#58)

### DIFF
--- a/js/interface.js
+++ b/js/interface.js
@@ -675,7 +675,7 @@
         rows = rows.filter(function(row) {
           var pageId = row.data && row.data.action && row.data.action.page;
 
-          return !pageId || !masterPageIds[pageId];
+          return !(pageId && masterPageIds[pageId]);
         });
 
         $('#menu-loading').hide();

--- a/js/interface.js
+++ b/js/interface.js
@@ -661,6 +661,23 @@
         }
 
         rows = Fliplet.Utils.sortBy(rows, 'data.order');
+
+        // Remove stale master page references that should have been replaced by production pages
+        var appPages = Fliplet.Env.get('appPages') || [];
+        var masterPageIds = {};
+
+        appPages.forEach(function(p) {
+          if (p.masterPageId) {
+            masterPageIds[p.masterPageId] = true;
+          }
+        });
+
+        rows = rows.filter(function(row) {
+          var pageId = row.data && row.data.action && row.data.action.page;
+
+          return !pageId || !masterPageIds[pageId];
+        });
+
         $('#menu-loading').hide();
         rows.forEach(function(row) {
           addLink(dataSource.id, row);
@@ -720,6 +737,7 @@
 
         // Update link label in case it was changed by the user
         menuItem.data.linkLabel = $('[data-id="' + menuItem.id + '"]').find('.link-label').val();
+        menuItem.data.entryId = menuItem.id;
         menuDataEntries.push(menuItem.data);
       }
     });


### PR DESCRIPTION
* Fix menu items duplication caused by missing entryId in mergeMenuEntries

Set entryId before pushing items in mergeMenuEntries() to prevent duplicate entries on subsequent saves. Also deduplicate rows by pageId on load to self-heal already corrupted menu data.

Ref: PS-1810



* Filter stale master page references using appPages masterPageId mapping

Use Fliplet.Env.get('appPages') to build a masterPageId lookup and filter out rows whose page ID matches a masterPageId. Safe for non-screen actions (documents, videos, URLs) as they have no pageId.



---------